### PR TITLE
fix: use bun@1.2.18

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2024-2025 Dyne.org foundation
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
-bun 1.2.19
+bun  1.2.18
 golang 1.24
 nodejs 24


### PR DESCRIPTION
bun 1.2.19 does not set right permission on windows executables (See https://github.com/oven-sh/bun/issues/21308)
